### PR TITLE
Fix normalize headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,13 +85,28 @@ export class ZenRows {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
     },
   ): Promise<Response> {
+    const normalizedHeaders = Object.keys(headers).reduce(
+      (acc: { [key: string]: string }, key: string) => {
+        const value = headers[key];
+        if (value !== undefined) {
+          if (key.toLowerCase() === "content-type") {
+            acc["Content-Type"] = value;
+          } else {
+            acc[key] = value;
+          }
+        }
+        return acc;
+      },
+      {},
+    );
+
     return this.queue.push({
       url,
       method: "POST",
       config,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
-        ...headers,
+        ...normalizedHeaders,
       },
       data,
     });


### PR DESCRIPTION
This PR resolves an issue where sending the `"content-type"` header in lowercase would cause invalid requests. Now, only headers that conflict with default ones (`"Content-Type"`) are normalized to ensure consistent request behavior without altering user-provided headers unnecessarily.