### PR TITLE
fix: off-by-one in retryOn — retries: 0 still retries once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,17 +42,13 @@ export class ZenRows {
     this.clientConfig = clientConfig;
     const retries = this.clientConfig.retries ?? 0;
 
-    this.queue = fastq.promise(
-      this,
-      this.worker,
-      this.clientConfig.concurrency ?? 5,
-    );
+    this.queue = fastq.promise(this, this.worker, this.clientConfig.concurrency ?? 5);
 
     this.fetchWithRetry = fetchRetry(fetch, {
       retryDelay: (attempt) => 2 ** attempt * 1000,
       // retryOn: [422, 503, 504],
       retryOn: (attempt, error, response) => {
-        if (attempt > retries) {
+        if (attempt >= retries) {
           return false;
         }
 
@@ -73,7 +69,7 @@ export class ZenRows {
   public get(
     url: string,
     config?: ZenRowsConfig,
-    { headers = {} }: { headers?: Headers } = {},
+    { headers = {} }: { headers?: Headers } = {}
   ): Promise<Response> {
     return this.queue.push({ url, config, headers });
   }
@@ -83,7 +79,7 @@ export class ZenRows {
     config?: ZenRowsConfig,
     { headers = {}, data = {} }: { headers?: Headers; data?: unknown } = {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    },
+    }
   ): Promise<Response> {
     const normalizedHeaders = Object.keys(headers).reduce(
       (acc: { [key: string]: string }, key: string) => {
@@ -97,7 +93,7 @@ export class ZenRows {
         }
         return acc;
       },
-      {},
+      {}
     );
 
     return this.queue.push({
@@ -160,10 +156,7 @@ export class ZenRows {
       }
     }
 
-    const response = await this.fetchWithRetry(
-      `${API_URL}?${params.toString()}`,
-      fetchOptions,
-    );
+    const response = await this.fetchWithRetry(`${API_URL}?${params.toString()}`, fetchOptions);
 
     return response;
   }

--- a/tests/retry-count.test.ts
+++ b/tests/retry-count.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "vitest";
+import { ZenRows } from "../src";
+import { server } from "./_setup";
+import { HttpResponse, http } from "msw";
+
+describe("retryOn off-by-one fix", () => {
+  test.each([
+    { retries: 0, expectedCalls: 1 },
+    { retries: 1, expectedCalls: 2 },
+    { retries: 2, expectedCalls: 3 },
+  ])(
+    "retries: $retries should make exactly $expectedCalls fetch call(s) on 422",
+    async ({ retries, expectedCalls }) => {
+      let fetchCount = 0;
+
+      server.use(
+        http.get("https://api.zenrows.com/v1/", () => {
+          fetchCount++;
+          return new HttpResponse("Could Not Get Content", { status: 422 });
+        })
+      );
+
+      const client = new ZenRows("API_KEY", { retries });
+      const response = await client.get("https://example.com");
+
+      expect(response.status).toBe(422);
+      expect(fetchCount).toBe(expectedCalls);
+    }
+  );
+});


### PR DESCRIPTION
Closes #15

## Bug

The `retryOn` callback in the constructor uses `attempt > retries` to decide whether to stop retrying. However, `fetch-retry` starts counting attempts at 0, so with the default `retries: 0`:

- `attempt=0`: `0 > 0` → `false` → enters retry logic → **retries once**
- `attempt=1`: `1 > 0` → `true` → stops

This means `retries: 0` (the default) actually performs **1 retry**, making 2 fetch calls total. The README states _"retries are not active by default"_, which contradicts this behavior.

## Fix

Change `attempt > retries` to `attempt >= retries` in the `retryOn` callback (one character change in `src/index.ts`).

With `>=`, `retries: 0` now correctly means zero retries:
- `attempt=0`: `0 >= 0` → `true` → stops immediately → **no retry**

## Tests

Added parameterized tests (`tests/retry-count.test.ts`) verifying exact fetch call counts:

| `retries` | Expected fetch calls | Behavior |
|-----------|---------------------|----------|
| 0 | 1 | No retry (default) |
| 1 | 2 | 1 retry |
| 2 | 3 | 2 retries |

All tests pass with the fix and fail without it.