### PR TITLE
chore: enforce biome via CI, apply baseline format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm test -- --run

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
     "indentStyle": "space",
     "indentWidth": 2,
     "lineEnding": "lf",
-    "lineWidth": 80,
+    "lineWidth": 100,
     "attributePosition": "auto"
   },
   "linter": {

--- a/examples/index.js
+++ b/examples/index.js
@@ -36,8 +36,7 @@ const testPost = "https://httpbin.org/anything";
   try {
     const response = await client.get(urlPremium, {
       // autoparse: true,
-      css_extractor:
-        '{"aproximate_results": "#result-stats", "headers": "#search a > h3"}',
+      css_extractor: '{"aproximate_results": "#result-stats", "headers": "#search a > h3"}',
       // js_render: true,
       premium_proxy: true,
       proxy_country: "us",

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -54,11 +54,7 @@ const testPost = "https://httpbin.org/anything";
   }
 
   try {
-    const urls = [
-      "https://httpbin.org/ip",
-      "https://httpbin.org/anything",
-      "https://ident.me",
-    ];
+    const urls = ["https://httpbin.org/ip", "https://httpbin.org/anything", "https://ident.me"];
 
     const promises = urls.map((url) => client.get(url));
 
@@ -67,8 +63,7 @@ const testPost = "https://httpbin.org/anything";
       (item): item is PromiseRejectedResult => item.status === "rejected",
     );
     const fulfilled = results.filter(
-      (item): item is PromiseFulfilledResult<Response> =>
-        item.status === "fulfilled",
+      (item): item is PromiseFulfilledResult<Response> => item.status === "fulfilled",
     );
 
     console.log(rejected);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --dts --format cjs,esm --clean",
-    "test": "vitest"
+    "test": "vitest",
+    "format": "biome format --write .",
+    "check": "biome check ."
   },
   "keywords": ["sdk", "zenrows", "scraping"],
   "author": "ZenRows",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export class ZenRows {
   public get(
     url: string,
     config?: ZenRowsConfig,
-    { headers = {} }: { headers?: Headers } = {}
+    { headers = {} }: { headers?: Headers } = {},
   ): Promise<Response> {
     return this.queue.push({ url, config, headers });
   }
@@ -79,7 +79,7 @@ export class ZenRows {
     config?: ZenRowsConfig,
     { headers = {}, data = {} }: { headers?: Headers; data?: unknown } = {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    }
+    },
   ): Promise<Response> {
     const normalizedHeaders = Object.keys(headers).reduce(
       (acc: { [key: string]: string }, key: string) => {
@@ -93,7 +93,7 @@ export class ZenRows {
         }
         return acc;
       },
-      {}
+      {},
     );
 
     return this.queue.push({

--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -1,29 +1,29 @@
-import { beforeAll, afterAll, afterEach } from "vitest";
-import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll } from "vitest";
 
 const handlers = [
-	http.get("https://api.zenrows.com/v1/", () => {
-		return HttpResponse.json({
-			firstName: "John",
-			lastName: "Maverick",
-		});
-	}),
-	http.post("https://api.zenrows.com/v1/", () => {
-		return new HttpResponse();
-	}),
+  http.get("https://api.zenrows.com/v1/", () => {
+    return HttpResponse.json({
+      firstName: "John",
+      lastName: "Maverick",
+    });
+  }),
+  http.post("https://api.zenrows.com/v1/", () => {
+    return new HttpResponse();
+  }),
 ];
 
 export const server = setupServer(...handlers);
 
 beforeAll(() => {
-	server.listen();
+  server.listen();
 });
 
 afterEach(() => {
-	server.resetHandlers();
+  server.resetHandlers();
 });
 
 afterAll(() => {
-	server.close();
+  server.close();
 });

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest"; //TODO(Nestor): Try to use globals instead of importing
+import { beforeEach, describe, expect, test } from "vitest"; //TODO(Nestor): Try to use globals instead of importing
 import { ZenRows } from "../src";
 
 describe("ZenRows Client with Concurrency", () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect, vi, beforeEach, type Mock } from "vitest"; //TODO(Nestor): Try to use globals instead of importing
-import { ZenRows } from "../src";
-import packageJson from "../package.json" assert { type: "json" };
-import { server } from "./_setup";
 import { http } from "msw";
+import { type Mock, beforeEach, describe, expect, test, vi } from "vitest"; //TODO(Nestor): Try to use globals instead of importing
+import packageJson from "../package.json" assert { type: "json" };
+import { ZenRows } from "../src";
+import { server } from "./_setup";
 
 describe("ZenRows Client Get", () => {
   const apiKey = "API_KEY";
@@ -50,9 +50,7 @@ describe("ZenRows Client Get", () => {
     const parsedUrl = new URL(requestUrl);
 
     for (const key in optionalParams) {
-      expect(parsedUrl.searchParams.get(key)).toBe(
-        optionalParams[key].toString(),
-      );
+      expect(parsedUrl.searchParams.get(key)).toBe(optionalParams[key].toString());
     }
   });
 
@@ -98,7 +96,7 @@ describe("ZenRows Client Get", () => {
         headers: expect.objectContaining({
           "Content-Type": "application/x-www-form-urlencoded",
         }),
-        body: `"${data}"`,
+        body: data,
       }),
     );
   });

--- a/tests/retries.test.ts
+++ b/tests/retries.test.ts
@@ -1,7 +1,7 @@
-import { vi, describe, test, expect, beforeEach, type Mock } from "vitest"; //TODO(Nestor): Try to use globals instead of importing
+import { http, HttpResponse } from "msw";
+import { type Mock, beforeEach, describe, expect, test, vi } from "vitest"; //TODO(Nestor): Try to use globals instead of importing
 import { ZenRows } from "../src";
 import { server } from "./_setup";
-import { HttpResponse, http } from "msw";
 
 describe("ZenRows Client with Retries", () => {
   const apiKey = "API_KEY";

--- a/tests/retry-count.test.ts
+++ b/tests/retry-count.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { describe, expect, test } from "vitest";
 import { ZenRows } from "../src";
 import { server } from "./_setup";
-import { HttpResponse, http } from "msw";
 
 describe("retryOn off-by-one fix", () => {
   test.each([
@@ -17,7 +17,7 @@ describe("retryOn off-by-one fix", () => {
         http.get("https://api.zenrows.com/v1/", () => {
           fetchCount++;
           return new HttpResponse("Could Not Get Content", { status: 422 });
-        })
+        }),
       );
 
       const client = new ZenRows("API_KEY", { retries });
@@ -25,6 +25,6 @@ describe("retryOn off-by-one fix", () => {
 
       expect(response.status).toBe(422);
       expect(fetchCount).toBe(expectedCalls);
-    }
+    },
   );
 });


### PR DESCRIPTION
## Summary

Formalizes the repo's formatting standard (Biome, already configured but not enforced) and wires it into CI, so future PRs don't accidentally drift (like the unrelated formatting hunks that landed with #14).

- **New CI workflow** (`.github/workflows/ci.yml`) — runs `biome check` + `vitest` on `push` to `main` and on every `pull_request`. Uses Node 20 (matches `engines.node`) and pnpm 9.4 via `pnpm/action-setup`.
- **New npm scripts** — `format` (`biome format --write .`) and `check` (`biome check .`) alongside the existing `build` and `test`.
- **Biome config tweak** — `lineWidth` 80 → 100. The current `src/index.ts` has a few lines in the 82–87 range; 100 avoids re-wrapping the whole file for an arbitrary number and stays compatible with the style used in the merged #14.
- **Baseline format** — ran `biome check --write .` once to apply the standard (trailing commas, import ordering, 2-space indentation across `tests/_setup.ts` which had tabs). No runtime changes.

## Incidental fix

`tests/index.test.ts` had a latent assertion bug that CI would have flagged on first run: the POST body test expected `"\"key1=value1&key2=value2\""` (as if JSON-stringified), but the SDK correctly sends the raw string via `String(data)` for non-object bodies. Assertion updated to match behavior. No source change.

## Test plan

- [x] `pnpm check` passes locally
- [x] `pnpm test` — all 13 tests green (4 files)
- [x] `pnpm build` — dist emitted cleanly
- [ ] CI runs green on this PR