### PR TITLE
chore: add release workflow (publish on GitHub Release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Verify tag matches package.json version
+        if: github.event_name == 'release'
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "tag $GITHUB_REF_NAME ($TAG) does not match package.json version $PKG"
+            exit 1
+          fi
+      - run: pnpm check
+      - run: pnpm test -- --run
+      - run: pnpm build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Formalizes npm publishing. Currently publishes are manual (`pnpm publish` from a maintainer's machine, untagged). This workflow automates it off a GitHub Release.

- **Trigger**: on `release: published` (plus `workflow_dispatch` as a manual fallback).
- **Flow**: checkout → pnpm/Node 20 → install (frozen) → verify tag matches `package.json` version → `pnpm check` → `pnpm test` → `pnpm build` → `npm publish --provenance --access public`.
- **Version guard**: if the release tag (e.g. `v2.0.2`) doesn't equal `package.json` version, the job fails before publishing.
- **Provenance**: stamps the package with its GitHub Actions origin (visible on the npm package page), so consumers can verify the build was produced by this repo.
- **Publish client**: uses `npm publish` (not `pnpm publish`) because npm + provenance is independent of the pnpm version pinned in `packageManager`.

## Prerequisites before the first release
## Intended release flow going forward

1. Open a version-bump PR (`chore: update version to X.Y.Z` — bumps `package.json` and `examples/package.json`).
2. Merge the PR.
3. Create a GitHub Release with tag `vX.Y.Z` and release notes.
4. This workflow runs automatically and publishes to npm.

## Test plan

- [x] YAML parses locally (syntax validated via workflow file structure)
- [ ] `NPM_TOKEN` secret added to repo
- [ ] First test release cuts `v2.0.2` and publishes successfully (separate PR for the version bump)