### PR TITLE
chore: update version to 2.0.2

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zenrows-examples",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ZenRows Node SDK Examples",
   "main": "index.js",
   "private": true,
@@ -9,6 +9,6 @@
   },
   "author": "ZenRows",
   "dependencies": {
-    "zenrows": "^2.0.1"
+    "zenrows": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zenrows",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ZenRows Node SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Version bump to 2.0.2 following the historical pattern (direct edits to the two `package.json` files).

## Release notes (for the GitHub Release body)

- **Fix** (#14, #15): `retries: 0` (the documented default of "no retries") now actually performs zero retries. Previously, off-by-one in the `retryOn` callback caused one extra fetch on `422/503/504` responses. Callers on defaults will see ~1 fewer request per transient failure. Thanks @jorgehermo9 for the report and fix.

## Notes

- `examples/package-lock.json` intentionally not refreshed here — the 2.0.2 tarball doesn't exist on npm yet. Refresh that in a small follow-up after publish (`cd examples && npm install`).
- New release workflow (#18) will trigger on the GitHub Release for `v2.0.2` and publish to npm. Requires `NPM_TOKEN` repo secret to be in place first.

## Test plan

- [x] Both `package.json` files bumped to 2.0.2
- [x] `examples/` dependency range bumped to `^2.0.2`
- [ ] CI green on this PR
- [ ] After merge: create GitHub Release `v2.0.2` with the notes above → release workflow publishes