### PR TITLE
chore: bump release workflow to Node 24 (ships npm 11)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: pnpm
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Single-line change: `node-version: 20` → `24` in `.github/workflows/release.yml`.

## Why

Node 24 LTS ships with **npm 11.x**, which supports OIDC publishing. Node 20 ships with npm 10.x (too old). This avoids the extra `npm install -g npm@latest` step we'd otherwise need in the publish job.

`engines.node` in `package.json` remains `>=20` — that's the consumer requirement and is unaffected. `ci.yml` (test job) also stays on Node 20 so we keep testing against what users actually run.

## Test plan

- [x] Diff is a single line
- [ ] CI green on PR (only `ci.yml` runs here; `release.yml` triggers only on `release: published` / `workflow_dispatch`)
- [ ] Verified on next release: `npm publish --provenance` works without the global-npm-install step